### PR TITLE
Update config manager file location

### DIFF
--- a/frontend/src/components/ConfigSetup.tsx
+++ b/frontend/src/components/ConfigSetup.tsx
@@ -227,7 +227,7 @@ const ConfigSetup: React.FC<ConfigSetupProps> = ({ onConfigComplete, isEditMode 
 
         <div className="mt-6 text-center">
           <p className="text-xs text-muted-foreground">
-            Configuration will be saved as <code className="bg-muted px-1 py-0.5 rounded text-xs">.atconfig</code> in the current directory
+            Configuration will be saved as <code className="bg-muted px-1 py-0.5 rounded text-xs">.atconfig</code> in your home directory
           </p>
         </div>
       </div>


### PR DESCRIPTION
Centralize `.atconfig` file management to only use the user's home directory.