### PR TITLE
Refactor edit dialogs into a single component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -60,7 +60,7 @@ function App() {
   // Replace transcript dialog state
   const [isReplaceDialogOpen, setIsReplaceDialogOpen] = useState(false)
   const [replaceTranscriptFilename, setReplaceTranscriptFilename] = useState('')
-  const [replaceTranscriptContent, setReplaceTranscriptContent] = useState('')
+  const [replaceTranscriptInitialContent, setReplaceTranscriptInitialContent] = useState('')
   const [isReplacingTranscript, setIsReplacingTranscript] = useState(false)
   
   // State for tracking out-of-view expanded rows
@@ -692,7 +692,7 @@ function App() {
       
       // Set up the replace dialog
       setReplaceTranscriptFilename(filename)
-      setReplaceTranscriptContent(transcriptContent)
+      setReplaceTranscriptInitialContent(transcriptContent)
       setIsReplaceDialogOpen(true)
       
     } catch (error) {
@@ -707,8 +707,8 @@ function App() {
     }
   }
 
-  const handleReplaceTranscript = async () => {
-    if (!replaceTranscriptFilename || !replaceTranscriptContent.trim()) return;
+  const handleReplaceTranscript = async (newText: string) => {
+    if (!replaceTranscriptFilename || !newText.trim()) return;
     
     setIsReplacingTranscript(true);
     try {
@@ -720,14 +720,14 @@ function App() {
           'X-CSRF-Token': csrfToken || '',
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ text: replaceTranscriptContent })
+        body: JSON.stringify({ text: newText })
       });
       
       if (response.ok) {
         // Update the transcript data with the new content
         setTranscriptData(prev => ({
           ...prev,
-          [replaceTranscriptFilename]: { text: replaceTranscriptContent, loading: false, error: null }
+          [replaceTranscriptFilename]: { text: newText, loading: false, error: null }
         }))
         
         // Force a refresh of the files list to update any metadata
@@ -744,7 +744,7 @@ function App() {
         // Close the dialog
         setIsReplaceDialogOpen(false)
         setReplaceTranscriptFilename('')
-        setReplaceTranscriptContent('')
+        setReplaceTranscriptInitialContent('')
       } else {
         const error = await response.json();
         alert(`Error: ${error.error || 'Failed to replace transcript'}`);
@@ -760,7 +760,7 @@ function App() {
   const handleReplaceCancel = () => {
     setIsReplaceDialogOpen(false)
     setReplaceTranscriptFilename('')
-    setReplaceTranscriptContent('')
+    setReplaceTranscriptInitialContent('')
   }
 
   const handleRegenerateMeta = async (filename: string, e: React.MouseEvent) => {
@@ -1166,8 +1166,7 @@ function App() {
       <EditDialog
         isOpen={isReplaceDialogOpen}
         title={`Replace Transcript - ${replaceTranscriptFilename}`}
-        value={replaceTranscriptContent}
-        onValueChange={setReplaceTranscriptContent}
+        initialValue={replaceTranscriptInitialContent}
         onSave={handleReplaceTranscript}
         onCancel={handleReplaceCancel}
         isSubmitting={isReplacingTranscript}

--- a/frontend/src/components/EditDialog.tsx
+++ b/frontend/src/components/EditDialog.tsx
@@ -3,9 +3,8 @@ import React from 'react';
 interface EditDialogProps {
   isOpen: boolean;
   title: string;
-  value: string;
-  onValueChange: (value: string) => void;
-  onSave: () => void;
+  initialValue: string;
+  onSave: (text: string) => void;
   onCancel: () => void;
   isSubmitting: boolean;
   placeholder?: string;
@@ -16,8 +15,7 @@ interface EditDialogProps {
 const EditDialog: React.FC<EditDialogProps> = ({
   isOpen,
   title,
-  value,
-  onValueChange,
+  initialValue,
   onSave,
   onCancel,
   isSubmitting,
@@ -25,6 +23,17 @@ const EditDialog: React.FC<EditDialogProps> = ({
   className = '',
   isLargeMode = false
 }) => {
+  const [text, setText] = React.useState(initialValue);
+
+  // Reset text when dialog opens/closes or initialValue changes
+  React.useEffect(() => {
+    setText(initialValue);
+  }, [initialValue, isOpen]);
+
+  const handleSave = () => {
+    onSave(text);
+  };
+
   if (!isOpen) return null;
 
   return (
@@ -33,8 +42,8 @@ const EditDialog: React.FC<EditDialogProps> = ({
         <h3 className="text-lg font-semibold mb-4">{title}</h3>
         
         <textarea
-          value={value}
-          onChange={(e) => onValueChange(e.target.value)}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
           className={`w-full ${isLargeMode ? 'h-96' : 'h-32'} p-3 border border-gray-300 dark:border-gray-600 rounded-md font-mono text-sm ${className}`}
           placeholder={placeholder}
         />
@@ -48,7 +57,7 @@ const EditDialog: React.FC<EditDialogProps> = ({
             Cancel
           </button>
           <button
-            onClick={onSave}
+            onClick={handleSave}
             disabled={isSubmitting}
             className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 disabled:opacity-50"
           >

--- a/frontend/src/components/TranscriptBlock.tsx
+++ b/frontend/src/components/TranscriptBlock.tsx
@@ -108,8 +108,8 @@ const TranscriptBlock: React.FC<TranscriptBlockProps> = ({
   };
 
   // Handle save edit
-  const handleSaveEdit = async () => {
-    if (editedText.trim() === text.trim()) {
+  const handleSaveEdit = async (newText: string) => {
+    if (newText.trim() === text.trim()) {
       setIsEditing(false);
       return;
     }
@@ -127,7 +127,7 @@ const TranscriptBlock: React.FC<TranscriptBlockProps> = ({
         },
         body: JSON.stringify({ 
           line_number: contentLineNumber.toString(), 
-          text: editedText 
+          text: newText 
         }),
       });
       if (response.ok) {
@@ -161,8 +161,8 @@ const TranscriptBlock: React.FC<TranscriptBlockProps> = ({
   };
 
   // Handle save timestamp edit
-  const handleSaveTimestampEdit = async () => {
-    if (editedTimestamp.trim() === `${startTime} --> ${endTime}`.trim()) {
+  const handleSaveTimestampEdit = async (newText: string) => {
+    if (newText.trim() === `${startTime} --> ${endTime}`.trim()) {
       setIsEditingTimestamp(false);
       return;
     }
@@ -180,7 +180,7 @@ const TranscriptBlock: React.FC<TranscriptBlockProps> = ({
         },
         body: JSON.stringify({ 
           line_number: lineNumber.toString(), 
-          text: editedTimestamp 
+          text: newText 
         }),
       });
 
@@ -326,8 +326,7 @@ const TranscriptBlock: React.FC<TranscriptBlockProps> = ({
       <EditDialog
         isOpen={isEditing}
         title={`Edit Line ${contentLineNumber}`}
-        value={editedText}
-        onValueChange={setEditedText}
+        initialValue={editedText}
         onSave={handleSaveEdit}
         onCancel={handleCancelEdit}
         isSubmitting={isSubmitting}
@@ -338,8 +337,7 @@ const TranscriptBlock: React.FC<TranscriptBlockProps> = ({
       <EditDialog
         isOpen={isEditingTimestamp}
         title={`Edit Timestamp Line ${timestampLineNumber}`}
-        value={editedTimestamp}
-        onValueChange={setEditedTimestamp}
+        initialValue={editedTimestamp}
         onSave={handleSaveTimestampEdit}
         onCancel={handleCancelTimestampEdit}
         isSubmitting={isSubmitting}


### PR DESCRIPTION
Simplify `EditDialog` API by managing internal text state and removing `onValueChange` to improve encapsulation and simplify parent component state.