### PR TITLE
Add ffmpeg and ffprobe path options

### DIFF
--- a/frontend/src/components/ConfigSetup.tsx
+++ b/frontend/src/components/ConfigSetup.tsx
@@ -17,6 +17,8 @@ interface ConfigData {
   whispercli_path: string;
   model_path?: string;
   model_name?: string;
+  ffmpeg_path: string;
+  ffprobe_path: string;
 }
 
 interface Model {
@@ -29,7 +31,9 @@ const ConfigSetup: React.FC<ConfigSetupProps> = ({ onConfigComplete, isEditMode 
   const [config, setConfig] = useState<ConfigData>({
     watch_directories: [''],
     whispercli_path: '',
-    model_path: ''
+    model_path: '',
+    ffmpeg_path: '',
+    ffprobe_path: ''
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
@@ -115,7 +119,9 @@ const ConfigSetup: React.FC<ConfigSetupProps> = ({ onConfigComplete, isEditMode 
               : [data.config.watch_directory || ''],
             whispercli_path: data.config.whispercli_path || '',
             model_path: data.config.model_path || '',
-            model_name: data.config.model_name || ''
+            model_name: data.config.model_name || '',
+            ffmpeg_path: data.config.ffmpeg_path || '',
+            ffprobe_path: data.config.ffprobe_path || ''
           };
           setConfig(configData);
           
@@ -142,6 +148,8 @@ const ConfigSetup: React.FC<ConfigSetupProps> = ({ onConfigComplete, isEditMode 
     
     return hasValidDirectories && 
            config.whispercli_path.trim() !== '' && 
+           config.ffmpeg_path.trim() !== '' &&
+           config.ffprobe_path.trim() !== '' &&
            hasModel;
   };
 
@@ -220,7 +228,9 @@ const ConfigSetup: React.FC<ConfigSetupProps> = ({ onConfigComplete, isEditMode 
     // Prepare submit data based on model selection
     const submitData: any = {
       watch_directories: filteredDirectories,
-      whispercli_path: config.whispercli_path
+      whispercli_path: config.whispercli_path,
+      ffmpeg_path: config.ffmpeg_path,
+      ffprobe_path: config.ffprobe_path
     };
 
     if (modelSelection === 'custom') {
@@ -393,6 +403,42 @@ const ConfigSetup: React.FC<ConfigSetupProps> = ({ onConfigComplete, isEditMode 
             )}
           </>
         )}
+      </div>
+
+      <div>
+        <label htmlFor="ffmpeg_path" className="block text-sm font-medium text-foreground mb-1">
+          FFmpeg Path
+        </label>
+        <input
+          type="text"
+          id="ffmpeg_path"
+          value={config.ffmpeg_path}
+          onChange={(e) => handleInputChange('ffmpeg_path', e.target.value)}
+          placeholder="/path/to/ffmpeg"
+          className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+          required
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Path to the ffmpeg executable (auto-detected if available in PATH)
+        </p>
+      </div>
+
+      <div>
+        <label htmlFor="ffprobe_path" className="block text-sm font-medium text-foreground mb-1">
+          FFprobe Path
+        </label>
+        <input
+          type="text"
+          id="ffprobe_path"
+          value={config.ffprobe_path}
+          onChange={(e) => handleInputChange('ffprobe_path', e.target.value)}
+          placeholder="/path/to/ffprobe"
+          className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+          required
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Path to the ffprobe executable (auto-detected if available in PATH)
+        </p>
       </div>
 
       {errors.length > 0 && (

--- a/lib/autotranscript/web/controllers/transcript_controller.ex
+++ b/lib/autotranscript/web/controllers/transcript_controller.ex
@@ -2,7 +2,7 @@ defmodule Autotranscript.Web.TranscriptController do
   use Autotranscript.Web, :controller
   require Logger
 
-  alias Autotranscript.{PathHelper, VideoInfoCache}
+  alias Autotranscript.{PathHelper, VideoInfoCache, ConfigManager}
 
   # Helper function to decode URL-encoded filenames
   def decode_filename(filename) when is_binary(filename) do
@@ -198,7 +198,8 @@ defmodule Autotranscript.Web.TranscriptController do
         temp_frame_path = Path.join(System.tmp_dir(), "random_frame_#{:rand.uniform(10000)}.jpg")
 
         # Use ffmpeg to extract a random frame
-        case System.cmd("ffmpeg", [
+        ffmpeg_path = ConfigManager.get_config_value("ffmpeg_path") || "ffmpeg"
+        case System.cmd(ffmpeg_path, [
           "-i", selected_file,
           "-vf", "select='gte(n\\,1)'",
           "-vframes", "1",
@@ -396,7 +397,8 @@ defmodule Autotranscript.Web.TranscriptController do
             end
 
             # Use ffmpeg to extract a frame at the specified time
-            case System.cmd("ffmpeg", ffmpeg_args) do
+            ffmpeg_path = ConfigManager.get_config_value("ffmpeg_path") || "ffmpeg"
+            case System.cmd(ffmpeg_path, ffmpeg_args) do
               {_output, 0} ->
                 # Successfully extracted frame, serve it
                 case File.read(temp_frame_path) do
@@ -528,7 +530,8 @@ defmodule Autotranscript.Web.TranscriptController do
             end
 
             # Use ffmpeg to extract and convert the video clip to MP4
-            case System.cmd("ffmpeg", ffmpeg_args) do
+            ffmpeg_path = ConfigManager.get_config_value("ffmpeg_path") || "ffmpeg"
+            case System.cmd(ffmpeg_path, ffmpeg_args) do
               {_output, 0} ->
                 # Successfully created clip, serve it
                 case File.read(temp_clip_path) do
@@ -690,7 +693,8 @@ defmodule Autotranscript.Web.TranscriptController do
 
   defp calculate_font_size_for_video(video_path, text_length) do
     # Get video dimensions using ffprobe
-    case System.cmd("ffprobe", [
+    ffprobe_path = ConfigManager.get_config_value("ffprobe_path") || "ffprobe"
+    case System.cmd(ffprobe_path, [
       "-v", "error",
       "-select_streams", "v:0",
       "-show_entries", "stream=width,height",


### PR DESCRIPTION
Add `ffmpeg_path` and `ffprobe_path` to the application configuration with auto-detection and UI support to ensure correct executable discovery and usage.