### PR TITLE
Restore scroll position when closing mobile components

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -282,6 +282,12 @@ export default function HomePage() {
         // Clear mobile clip player
         setMobileClipPlayerComponent(null)
         setIsAtTop(true)
+        // Restore scroll position after component unmounts
+        setTimeout(() => {
+          if (leftPaneRef.current) {
+            leftPaneRef.current.scrollTop = leftPaneScrollOffset
+          }
+        }, 0)
       }
     } else {
       // On desktop, set the component directly
@@ -299,6 +305,12 @@ export default function HomePage() {
           <ConfigPage onClose={() => {
             setMobileConfigComponent(null)
             setIsAtTop(true)
+            // Restore scroll position after component unmounts
+            setTimeout(() => {
+              if (leftPaneRef.current) {
+                leftPaneRef.current.scrollTop = leftPaneScrollOffset
+              }
+            }, 0)
           }} />
         </div>
       )
@@ -322,6 +334,12 @@ export default function HomePage() {
           <QueuePage onClose={() => {
             setMobileQueueComponent(null)
             setIsAtTop(true)
+            // Restore scroll position after component unmounts
+            setTimeout(() => {
+              if (leftPaneRef.current) {
+                leftPaneRef.current.scrollTop = leftPaneScrollOffset
+              }
+            }, 0)
           }} />
         </div>
       )
@@ -358,6 +376,12 @@ export default function HomePage() {
                 // On mobile, just hide the clip player but keep clip times
                 setMobileClipPlayerComponent(null)
                 setIsAtTop(true)
+                // Restore scroll position after component unmounts
+                setTimeout(() => {
+                  if (leftPaneRef.current) {
+                    leftPaneRef.current.scrollTop = leftPaneScrollOffset
+                  }
+                }, 0)
               } else {
                 // On desktop, clear everything as before
                 setRightPaneComponent(null)
@@ -392,6 +416,12 @@ export default function HomePage() {
                 // On mobile, just hide the clip player but keep clip times
                 setMobileClipPlayerComponent(null)
                 setIsAtTop(true)
+                // Restore scroll position after component unmounts
+                setTimeout(() => {
+                  if (leftPaneRef.current) {
+                    leftPaneRef.current.scrollTop = leftPaneScrollOffset
+                  }
+                }, 0)
               } else {
                 // On desktop, clear everything as before
                 setRightPaneComponent(null)
@@ -446,6 +476,12 @@ export default function HomePage() {
     // Reset scroll position state when clearing on mobile
     if (isSmallScreen) {
       setIsAtTop(true)
+      // Restore scroll position after component unmounts
+      setTimeout(() => {
+        if (leftPaneRef.current) {
+          leftPaneRef.current.scrollTop = leftPaneScrollOffset
+        }
+      }, 0)
     }
   }
 
@@ -474,6 +510,12 @@ export default function HomePage() {
                 // On mobile, just hide the clip player but keep clip times
                 setMobileClipPlayerComponent(null)
                 setIsAtTop(true)
+                // Restore scroll position after component unmounts
+                setTimeout(() => {
+                  if (leftPaneRef.current) {
+                    leftPaneRef.current.scrollTop = leftPaneScrollOffset
+                  }
+                }, 0)
               } else {
                 // On desktop, clear everything as before
                 setRightPaneComponent(null)


### PR DESCRIPTION
## Summary
- Store left pane scroll offset in state variable that updates during scrolling
- Automatically restore scroll position when closing non-transcript-list pages on mobile
- Applies to config page, queue page, clip player, and all clip-related close actions

## Test plan
- [ ] Navigate to transcript list on mobile and scroll down
- [ ] Open config page, then close it - should return to previous scroll position
- [ ] Open queue page, then close it - should return to previous scroll position  
- [ ] Open clip player, then close it - should return to previous scroll position
- [ ] Verify desktop behavior remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)