### PR TITLE
Use dirs crate for home directory

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -43,8 +43,8 @@ pub fn get_video_extensions() -> Vec<&'static str> {
 }
 
 pub fn get_cache_file_path() -> std::path::PathBuf {
-    let home_dir = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    std::path::Path::new(&home_dir).join(".atci/.video_info_cache.msgpack")
+    let home_dir = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    home_dir.join(".atci/.video_info_cache.msgpack")
 }
 
 pub fn save_video_info_to_cache(cache_data: &CacheData) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/model_manager.rs
+++ b/src/model_manager.rs
@@ -48,8 +48,8 @@ pub struct ModelInfo {
 }
 
 pub fn models_directory() -> std::path::PathBuf {
-    let home_dir = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    std::path::Path::new(&home_dir).join(".atci").join("models")
+    let home_dir = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    home_dir.join(".atci").join("models")
 }
 
 pub fn list_models() -> Vec<ModelInfo> {

--- a/src/tools_manager.rs
+++ b/src/tools_manager.rs
@@ -62,8 +62,8 @@ pub fn get_whisper_cli_sha256(platform: &str) -> Option<&'static str> {
 }
 
 pub fn binaries_directory(tool: &str) -> std::path::PathBuf {
-    let home_dir = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    std::path::Path::new(&home_dir).join(".atci").join(tool)
+    let home_dir = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    home_dir.join(".atci").join(tool)
 }
 
 #[derive(Debug, serde::Serialize)]

--- a/src/video_processor.rs
+++ b/src/video_processor.rs
@@ -12,15 +12,15 @@ use tokio::time::sleep;
 use std::time::Duration;
 
 fn check_cancel_file() -> bool {
-    let home_dir = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    let cancel_file = std::path::Path::new(&home_dir).join(".atci").join(".commands").join("CANCEL");
+    let home_dir = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let cancel_file = home_dir.join(".atci").join(".commands").join("CANCEL");
     cancel_file.exists()
 }
 
 fn cleanup_cancel_and_processing_files(video_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let home_dir = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    let cancel_file = std::path::Path::new(&home_dir).join(".atci").join(".commands").join("CANCEL");
-    let currently_processing_path = std::path::Path::new(&home_dir).join(".atci/.currently_processing");
+    let home_dir = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let cancel_file = home_dir.join(".atci").join(".commands").join("CANCEL");
+    let currently_processing_path = home_dir.join(".atci/.currently_processing");
     let mp3_path = video_path.with_extension("mp3");
     
     // Remove cancel file
@@ -355,12 +355,12 @@ pub async fn cancellable_create_transcript(video_path: &Path) -> Result<bool, Bo
             
             // Transcribe audio with cancellation check
             println!("Transcribing audio");
-            let home_dir = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-            let model_path = format!("{}/.atci/models/{}.bin", home_dir, cfg.model_name);
+            let home_dir = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+            let model_path = home_dir.join(".atci/models").join(format!("{}.bin", cfg.model_name));
             
             let mut child = Command::new(&cfg.whispercli_path)
                 .args(&[
-                    "-m", &model_path,
+                    "-m", model_path.to_str().unwrap(),
                     "-np",
                     "--max-context", "0",
                     "-ovtt",


### PR DESCRIPTION
Replace direct `std::env::var("HOME")` calls with `dirs::home_dir()` for improved cross-platform home directory detection and error handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cd09fa1-c8e7-4fd1-9f21-8d2444a69025">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3cd09fa1-c8e7-4fd1-9f21-8d2444a69025">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

