### PR TITLE
Implement self update and version commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,18 +80,12 @@ jobs:
           key: ${{ matrix.target }}
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
-      - name: Rename binary (Unix)
-        if: matrix.os != 'windows-latest'
-        run: mv target/${{ matrix.target }}/release/${{ matrix.artifact_name }} target/${{ matrix.target }}/release/${{ matrix.asset_name }}
-      - name: Rename binary (Windows)
-        if: matrix.os == 'windows-latest'
-        run: mv target/${{ matrix.target }}/release/${{ matrix.artifact_name }} target/${{ matrix.target }}/release/${{ matrix.asset_name }}
       - name: Upload build artifact
         id: upload-artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
-          path: target/${{ matrix.target }}/release/${{ matrix.asset_name }}
+          path: target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
           retention-days: 30
 
   download-urls:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact_name: atci.exe
-            asset_name: atci-windows-x86_64.exe
+            asset_name: atci-windows-x86_64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -122,7 +122,7 @@ jobs:
             // Find artifact IDs by name
             const linuxArtifact = artifacts.data.artifacts.find(a => a.name === 'atci-linux-x86_64');
             const macosArtifact = artifacts.data.artifacts.find(a => a.name === 'atci-macos-aarch64');
-            const windowsArtifact = artifacts.data.artifacts.find(a => a.name === 'atci-windows-x86_64.exe');
+            const windowsArtifact = artifacts.data.artifacts.find(a => a.name === 'atci-windows-x86_64');
 
             const comment = `## 🚀 Build Artifacts Ready!
 
@@ -130,7 +130,7 @@ jobs:
             |----------|--------------|--------------|
             | Linux | x86_64 | [atci-linux-x86_64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${linuxArtifact?.id || 'not-found'}) |
             | macOS | ARM64 | [atci-macos-aarch64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${macosArtifact?.id || 'not-found'}) |
-            | Windows | x86_64 | [atci-windows-x86_64.exe](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${windowsArtifact?.id || 'not-found'}) |
+            | Windows | x86_64 | [atci-windows-x86_64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${windowsArtifact?.id || 'not-found'}) |
 
             *Built from commit ${{ github.sha }}*`;
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
           - os: macos-latest
             target: aarch64-apple-darwin
           - os: windows-latest
@@ -63,10 +61,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            artifact_name: atci
-            asset_name: atci-linux-x86_64
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact_name: atci
@@ -120,7 +114,6 @@ jobs:
             });
 
             // Find artifact IDs by name
-            const linuxArtifact = artifacts.data.artifacts.find(a => a.name === 'atci-linux-x86_64');
             const macosArtifact = artifacts.data.artifacts.find(a => a.name === 'atci-macos-aarch64');
             const windowsArtifact = artifacts.data.artifacts.find(a => a.name === 'atci-windows-x86_64');
 
@@ -128,7 +121,6 @@ jobs:
 
             | Platform | Architecture | Download URL |
             |----------|--------------|--------------|
-            | Linux | x86_64 | [atci-linux-x86_64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${linuxArtifact?.id || 'not-found'}) |
             | macOS | ARM64 | [atci-macos-aarch64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${macosArtifact?.id || 'not-found'}) |
             | Windows | x86_64 | [atci-windows-x86_64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${windowsArtifact?.id || 'not-found'}) |
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build for ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: windows-x86_64
+            os: windows-latest
+            rust_target: x86_64-pc-windows-msvc
+            binary_name: atci.exe
+            zip_name: atci-windows-x86_64.zip
+          - target: macos-aarch64
+            os: macos-latest
+            rust_target: aarch64-apple-darwin
+            binary_name: atci
+            zip_name: atci-macos-aarch64.zip
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install system dependencies (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          # Install any required system dependencies for macOS
+          echo "Installing macOS dependencies..."
+
+      - name: Install system dependencies (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          # Install any required system dependencies for Windows
+          echo "Installing Windows dependencies..."
+
+      - name: Build release binary
+        run: |
+          cargo build --release --target ${{ matrix.rust_target }}
+
+      - name: Create ZIP archive (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          cd target/${{ matrix.rust_target }}/release
+          7z a ../../../${{ matrix.zip_name }} ${{ matrix.binary_name }}
+
+      - name: Create ZIP archive (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          cd target/${{ matrix.rust_target }}/release
+          zip ../../../${{ matrix.zip_name }} ${{ matrix.binary_name }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.zip_name }}
+          path: ${{ matrix.zip_name }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Windows Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./atci-windows-x86_64.zip/atci-windows-x86_64.zip
+          asset_name: atci-windows-x86_64.zip
+          asset_content_type: application/zip
+
+      - name: Upload macOS Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./atci-macos-aarch64.zip/atci-macos-aarch64.zip
+          asset_name: atci-macos-aarch64.zip
+          asset_content_type: application/zip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "binascii"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,10 +590,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -726,6 +775,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +859,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "figment"
@@ -2055,6 +2135,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,6 +2723,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2773,6 +2872,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "urlencoding",
+ "zip",
+ "zipsign-api",
 ]
 
 [[package]]
@@ -2887,6 +2988,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,6 +3040,16 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "stable-pattern"
@@ -4170,6 +4291,16 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
+]
+
+[[package]]
+name = "zipsign-api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
+dependencies = [
+ "ed25519-dalek",
+ "thiserror 2.0.15",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "globset",
- "indicatif",
+ "indicatif 0.18.0",
  "predicates",
  "rayon",
  "regex",
@@ -183,6 +183,7 @@ dependencies = [
  "rocket_dyn_templates",
  "rusqlite",
  "rust-embed",
+ "self_update",
  "serde",
  "serde_json",
  "sha2",
@@ -970,8 +971,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1232,6 +1235,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1416,6 +1420,19 @@ dependencies = [
  "equivalent",
  "hashbrown",
  "serde",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
 ]
 
 [[package]]
@@ -1634,6 +1651,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lzma-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1846,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -2114,6 +2143,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.0",
+ "thiserror 2.0.15",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.15",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.0",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2135,8 +2228,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2146,7 +2249,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2156,6 +2269,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -2299,6 +2421,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2306,6 +2430,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2313,6 +2438,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2372,7 +2498,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -2501,6 +2627,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2532,6 +2665,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2610,6 +2744,42 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "self_update"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
+dependencies = [
+ "hyper 1.7.0",
+ "indicatif 0.17.11",
+ "log",
+ "quick-xml",
+ "regex",
+ "reqwest",
+ "self-replace",
+ "semver",
+ "serde_json",
+ "tempfile",
+ "urlencoding",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -2956,6 +3126,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3436,6 +3621,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ dirs = "5.0"
 ctrlc = "3.4"
 indicatif = "0.18"
 rusqlite = { version = "0.37.0", features = ["bundled"] }
-self_update = "0.42"
+self_update = { version = "0.42", features = ["archive-zip"] }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ dirs = "5.0"
 ctrlc = "3.4"
 indicatif = "0.18"
 rusqlite = { version = "0.37.0", features = ["bundled"] }
+self_update = "0.42"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,17 @@ enum Commands {
         #[command(subcommand)]
         web_command: Option<WebCommands>,
     },
+    #[command(about = "Update atci to the latest version from GitHub releases")]
+    Update,
+    #[command(about = "Display version information and check for updates")]
+    Version {
+        #[arg(
+            long,
+            help = "Show formatted output instead of JSON",
+            default_value = "false"
+        )]
+        pretty: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -840,6 +851,71 @@ fn setup_pid_file_management() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn update() -> Result<(), Box<dyn std::error::Error>> {
+    use self_update::cargo_crate_version;
+
+    let status = self_update::backends::github::Update::configure()
+        .repo_owner("andrewnissen")
+        .repo_name("atci")
+        .bin_name("atci")
+        .show_download_progress(true)
+        .current_version(cargo_crate_version!())
+        .build()?
+        .update()?;
+
+    println!("Update status: `{}`", status.version());
+    Ok(())
+}
+
+fn check_version(pretty: bool) -> Result<(), Box<dyn std::error::Error>> {
+    use self_update::cargo_crate_version;
+    use serde_json::json;
+
+    let current_version = cargo_crate_version!();
+    
+    // Check for latest release
+    let (latest_version, update_available) = match self_update::backends::github::ReleaseList::configure()
+        .repo_owner("andrewnissen")
+        .repo_name("atci")
+        .build()
+        .and_then(|r| r.fetch())
+    {
+        Ok(releases) => {
+            let latest_release = releases.first();
+            let latest_version = latest_release.map(|r| r.version.as_str()).unwrap_or("unknown");
+            let update_available = latest_release
+                .map(|r| r.version.as_str() != current_version)
+                .unwrap_or(false);
+            (latest_version.to_string(), update_available)
+        }
+        Err(_) => {
+            // If we can't fetch releases (repository doesn't exist, network issues, etc.)
+            ("unknown".to_string(), false)
+        }
+    };
+
+    if pretty {
+        println!("Current version: {}", current_version);
+        println!("Latest version: {}", latest_version);
+        if latest_version == "unknown" {
+            println!("ℹ️  Could not check for updates (repository may not exist or have releases)");
+        } else if update_available {
+            println!("🔔 Update available! Run 'atci update' to update to the latest version.");
+        } else {
+            println!("✅ You are running the latest version.");
+        }
+    } else {
+        let version_info = json!({
+            "current_version": current_version,
+            "latest_version": latest_version,
+            "update_available": update_available
+        });
+        println!("{}", serde_json::to_string_pretty(&version_info)?);
+    }
+
+    Ok(())
+}
+
 fn validate_and_prompt_config(
     cfg: &mut AtciConfig,
     fields_to_verify: &HashSet<String>,
@@ -1393,6 +1469,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     });
                 }
                 None => {}
+            }
+        }
+        Some(Commands::Update) => {
+            if let Err(e) = update() {
+                eprintln!("Error updating: {}", e);
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Version { pretty }) => {
+            if let Err(e) = check_version(pretty) {
+                eprintln!("Error checking version: {}", e);
+                std::process::exit(1);
             }
         }
         None => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -886,27 +886,30 @@ fn check_version(pretty: bool) -> Result<(), Box<dyn std::error::Error>> {
     use serde_json::json;
 
     let current_version = cargo_crate_version!();
-    
+
     // Check for latest release
-    let (latest_version, update_available) = match self_update::backends::github::ReleaseList::configure()
-        .repo_owner("adnissen")
-        .repo_name("atci")
-        .build()
-        .and_then(|r| r.fetch())
-    {
-        Ok(releases) => {
-            let latest_release = releases.first();
-            let latest_version = latest_release.map(|r| r.version.as_str()).unwrap_or("unknown");
-            let update_available = latest_release
-                .map(|r| r.version.as_str() != current_version)
-                .unwrap_or(false);
-            (latest_version.to_string(), update_available)
-        }
-        Err(_) => {
-            // If we can't fetch releases (repository doesn't exist, network issues, etc.)
-            ("unknown".to_string(), false)
-        }
-    };
+    let (latest_version, update_available) =
+        match self_update::backends::github::ReleaseList::configure()
+            .repo_owner("adnissen")
+            .repo_name("atci")
+            .build()
+            .and_then(|r| r.fetch())
+        {
+            Ok(releases) => {
+                let latest_release = releases.first();
+                let latest_version = latest_release
+                    .map(|r| r.version.as_str())
+                    .unwrap_or("unknown");
+                let update_available = latest_release
+                    .map(|r| r.version.as_str() != current_version)
+                    .unwrap_or(false);
+                (latest_version.to_string(), update_available)
+            }
+            Err(_) => {
+                // If we can't fetch releases (repository doesn't exist, network issues, etc.)
+                ("unknown".to_string(), false)
+            }
+        };
 
     if pretty {
         println!("Current version: {}", current_version);

--- a/src/main.rs
+++ b/src/main.rs
@@ -854,10 +854,24 @@ fn setup_pid_file_management() -> Result<(), Box<dyn std::error::Error>> {
 fn update() -> Result<(), Box<dyn std::error::Error>> {
     use self_update::cargo_crate_version;
 
+    // Determine the target and binary name based on the current platform
+    let (target, bin_name) = if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+        ("windows-x86_64", "atci.exe")
+    } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        ("macos-aarch64", "atci")
+    } else {
+        return Err(format!(
+            "Self-update is only supported for Windows x86_64 and macOS aarch64. Current platform: {}-{}",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        ).into());
+    };
+
     let status = self_update::backends::github::Update::configure()
         .repo_owner("adnissen")
         .repo_name("atci")
-        .bin_name("atci")
+        .bin_name(bin_name)
+        .target(target)
         .show_download_progress(true)
         .current_version(cargo_crate_version!())
         .build()?

--- a/src/main.rs
+++ b/src/main.rs
@@ -855,7 +855,7 @@ fn update() -> Result<(), Box<dyn std::error::Error>> {
     use self_update::cargo_crate_version;
 
     let status = self_update::backends::github::Update::configure()
-        .repo_owner("andrewnissen")
+        .repo_owner("adnissen")
         .repo_name("atci")
         .bin_name("atci")
         .show_download_progress(true)
@@ -875,7 +875,7 @@ fn check_version(pretty: bool) -> Result<(), Box<dyn std::error::Error>> {
     
     // Check for latest release
     let (latest_version, update_available) = match self_update::backends::github::ReleaseList::configure()
-        .repo_owner("andrewnissen")
+        .repo_owner("adnissen")
         .repo_name("atci")
         .build()
         .and_then(|r| r.fetch())


### PR DESCRIPTION
Add `update` and `version` commands to enable self-updating the `atci` tool from GitHub releases and displaying version information.

The `version` command provides both machine-readable JSON output and a human-friendly pretty format, including a check for new releases. The `update` command leverages the `self_update` crate to seamlessly download and install the latest binary from the `adnissen/atci` GitHub repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b4f261a-1266-4b1d-925c-92a8bfacee2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b4f261a-1266-4b1d-925c-92a8bfacee2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

